### PR TITLE
Fix build, improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Jena uses a mixture of lower/uppercase (following the case in the vocabularies).
 ## Example
 
 ```
-java -jar vocgen.jar --file <local_vocab_owl.ttl> --doc <vocab_human_doc_url>
+java -jar target/vocgen-[version]-with-dependencies.jar --file <local_vocab_owl.ttl> --doc <vocab_human_doc_url>
 	--ns <namespace_uri> --prefix <preferred_prefix>
 	--short <short_vocabulary_name> --long <long_vocabulary_name>
 	--author <name_java_author>
@@ -40,6 +40,8 @@ To include this generator in a maven toolchain, add the dependency to your pom f
         </execution>
     </executions>
     <configuration>
+        <includeProjectDependencies>false</includeProjectDependencies> <!-- unless your ontology/copyright file is in a project dependency -->
+        <includePluginDependencies>true</includePluginDependencies>    
         <mainClass>be.belgif.vocgen.Main</mainClass>
         <arguments>
             <argument>--searchClasspath</argument> <!-- if your ontology/copyright are on the classpath -->  
@@ -55,6 +57,14 @@ To include this generator in a maven toolchain, add the dependency to your pom f
             <argument>--template</argument><argument>rdf4j</argument>
         </arguments>
     </configuration>
+     <dependencies>
+        <dependency>
+            <groupId>be.belgif</groupId>
+            <artifactId>VocGen</artifactId>
+            <version>1.0.3</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </plugin>
 <plugin>
     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,16 +65,26 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                        <goal>shade</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>be.belgif.vocgen.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* shade plugin is no good for just generating an executable uber jar but shipping a normal, small jar that supports ususal dependency management. Replaced with assembly plugin
* improved docs on maven usage - this version does not pollute the project with this project and its transitive dependencies